### PR TITLE
Add async per-user locks and safe LRU eviction with resource cleanup to team cache

### DIFF
--- a/agent/agent_factory.py
+++ b/agent/agent_factory.py
@@ -1,5 +1,7 @@
 import os
 import logging
+import asyncio
+from typing import Dict
 from sqlalchemy.engine import make_url
 from core.observability import setup_phoenix_tracing
 
@@ -332,6 +334,25 @@ Be precise with timestamps and attribute statements accurately to users."""
 # -------------------------------------------------------------
 from collections import OrderedDict
 _user_teams = OrderedDict()
+_user_team_locks: Dict[str, asyncio.Lock] = {}
+_user_team_locks_guard = asyncio.Lock()
+_user_teams_lock = asyncio.Lock()
+
+
+async def _get_user_team_lock(user_id: str) -> asyncio.Lock:
+    """Return a per-user lock, creating it exactly once in a race-safe way."""
+    async with _user_team_locks_guard:
+        lock = _user_team_locks.get(user_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            _user_team_locks[user_id] = lock
+        return lock
+
+
+async def _remove_user_team_lock(user_id: str) -> None:
+    """Drop a stale lock after a user's team is evicted from cache."""
+    async with _user_team_locks_guard:
+        _user_team_locks.pop(user_id, None)
 
 
 async def get_or_create_team(user_id: str, client=None):
@@ -340,44 +361,64 @@ async def get_or_create_team(user_id: str, client=None):
     Uses LRU eviction if cache exceeds MAX_AGENTS.
     Implements proper resource cleanup when evicting teams.
     """
-    if user_id in _user_teams:
-        # Move to end (mark as recently used)
-        _user_teams.move_to_end(user_id)
-        return _user_teams[user_id]
+    user_lock = await _get_user_team_lock(user_id)
+    async with user_lock:
+        oldest_team = None
+        oldest_user = None
 
-    # If cache full, evict oldest (least recently used) team
-    if len(_user_teams) >= MAX_AGENTS:
-        oldest_user, oldest_team = _user_teams.popitem(last=False)
-        logger.info(f"[TeamCache] Evicting team for user {oldest_user} (cache size: {MAX_AGENTS})")
-        
-        # Cleanup evicted team resources
-        try:
-            # Cleanup MCP connections if any
-            if hasattr(oldest_team, 'members'):
-                for member in oldest_team.members:
-                    # Check if member has MCP tools that need cleanup
-                    if hasattr(member, 'tools'):
-                        for tool in member.tools:
-                            if hasattr(tool, 'close'):
-                                try:
-                                    if hasattr(tool.close, '__await__'):
-                                        await tool.close()
-                                    else:
-                                        tool.close()
-                                except Exception as e:
-                                    logger.warning(f"[TeamCache] Error closing tool: {e}")
-            
-            # Cleanup team-level resources if available
-            if hasattr(oldest_team, 'cleanup'):
-                if hasattr(oldest_team.cleanup, '__await__'):
-                    await oldest_team.cleanup()
-                else:
-                    oldest_team.cleanup()
-        except Exception as e:
-            logger.error(f"[TeamCache] Error during team cleanup: {e}", exc_info=True)
+        async with _user_teams_lock:
+            if user_id in _user_teams:
+                # Move to end (mark as recently used)
+                _user_teams.move_to_end(user_id)
+                return _user_teams[user_id]
 
-    _, team = create_team_for_user(user_id, client=client)
-    _user_teams[user_id] = team
-    logger.info(f"[TeamCache] Created new team for user {user_id} (cache size: {len(_user_teams)}/{MAX_AGENTS})")
+            # If cache full, evict oldest (least recently used) team
+            if len(_user_teams) >= MAX_AGENTS:
+                oldest_user, oldest_team = _user_teams.popitem(last=False)
 
-    return team
+        if oldest_team is not None:
+            logger.info(f"[TeamCache] Evicting team for user {oldest_user} (cache size: {MAX_AGENTS})")
+            if oldest_user is not None:
+                await _remove_user_team_lock(oldest_user)
+
+            # Cleanup evicted team resources
+            try:
+                # Cleanup MCP connections if any
+                if hasattr(oldest_team, 'members'):
+                    for member in oldest_team.members:
+                        # Check if member has MCP tools that need cleanup
+                        if hasattr(member, 'tools'):
+                            for tool in member.tools:
+                                if hasattr(tool, 'close'):
+                                    try:
+                                        if hasattr(tool.close, '__await__'):
+                                            await tool.close()
+                                        else:
+                                            tool.close()
+                                    except Exception as e:
+                                        logger.warning(f"[TeamCache] Error closing tool: {e}")
+
+                # Cleanup team-level resources if available
+                if hasattr(oldest_team, 'cleanup'):
+                    if hasattr(oldest_team.cleanup, '__await__'):
+                        await oldest_team.cleanup()
+                    else:
+                        oldest_team.cleanup()
+            except Exception as e:
+                logger.error(f"[TeamCache] Error during team cleanup: {e}", exc_info=True)
+
+        _, team = create_team_for_user(user_id, client=client)
+
+        async with _user_teams_lock:
+            # Defensive re-check: if team was inserted unexpectedly, return it.
+            existing_team = _user_teams.get(user_id)
+            if existing_team is not None:
+                _user_teams.move_to_end(user_id)
+                return existing_team
+
+            _user_teams[user_id] = team
+            cache_size = len(_user_teams)
+
+        logger.info(f"[TeamCache] Created new team for user {user_id} (cache size: {cache_size}/{MAX_AGENTS})")
+
+        return team


### PR DESCRIPTION
### Motivation

- Make `get_or_create_team` safe under concurrent async calls to avoid duplicate team creation and races. 
- Ensure LRU eviction properly cleans up resources (tools/MCP connections and team-level cleanup) to prevent leaks. 
- Provide per-user lock lifecycle management so stale locks are removed when teams are evicted. 

### Description

- Added `asyncio`-based concurrency primitives and types with new module-level variables ` _user_team_locks`, `_user_team_locks_guard`, and `_user_teams_lock`. 
- Implemented helper functions ` _get_user_team_lock(user_id: str)` and ` _remove_user_team_lock(user_id: str)` to create and drop per-user locks in a race-safe way. 
- Rewrote `get_or_create_team` to acquire a per-user lock, use a global `_user_teams_lock` for short critical sections, perform LRU eviction outside the global lock, run async-aware cleanup for evicted teams/tools, and perform a defensive re-check before inserting a newly created team. 
- Preserved existing cleanup semantics by detecting and awaiting async `close`/`cleanup` callables and added logging around eviction and cleanup operations. 

### Testing

- Ran the repository unit test suite including async cache-related tests and all tests completed successfully. 
- Ran static checks/linters and CI integration checks and they passed without errors. 
- Executed a concurrency smoke test for `get_or_create_team` under concurrent requests and observed no duplicate creations or resource leaks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3dfff77148330b086e16d5f7e6212)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the team creation and management system with improved concurrency control to ensure thread-safe operations across multiple concurrent requests. Optimized cache management and resource cleanup procedures with more robust error handling during team eviction and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->