### PR TITLE
Restrict Discord chatbot invocations to authorized users

### DIFF
--- a/discord_bot/chat_handler.py
+++ b/discord_bot/chat_handler.py
@@ -122,11 +122,6 @@ def setup_chat(bot):
         chatbot_prefix = "!"
         if message.content.startswith(chatbot_prefix):
             if str(message.author.id) not in ALLOWED_USER_IDS:
-                logger.warning(
-                    "[chatbot] Ignoring unauthorized user %s in channel %s",
-                    message.author.id,
-                    message.channel.id,
-                )
                 return
 
             # Step 1: replace mentions with readable form for context

--- a/discord_bot/chat_handler.py
+++ b/discord_bot/chat_handler.py
@@ -1,5 +1,6 @@
 # chat_handler.py
 import logging
+import os
 import sys
 import time
 from discord_bot.discord_utils import resolve_mentions, restore_mentions, correct_mentions
@@ -21,6 +22,12 @@ import asyncio
 import discord
 
 logger = logging.getLogger(__name__)
+
+ALLOWED_USER_IDS = {
+    user_id.strip()
+    for user_id in os.getenv("ALLOWED_USER_IDS", "").split(",")
+    if user_id.strip()
+}
 
 async def async_ask_junkie(user_text: str, user_id: str, session_id: str, images: list = None, client=None) -> str:
     """
@@ -114,6 +121,14 @@ def setup_chat(bot):
         # Chatbot prefix (!) — handle via Team
         chatbot_prefix = "!"
         if message.content.startswith(chatbot_prefix):
+            if str(message.author.id) not in ALLOWED_USER_IDS:
+                logger.warning(
+                    "[chatbot] Ignoring unauthorized user %s in channel %s",
+                    message.author.id,
+                    message.channel.id,
+                )
+                return
+
             # Step 1: replace mentions with readable form for context
             processed_content = resolve_mentions(message)
             


### PR DESCRIPTION
### Motivation
- Prevent arbitrary Discord users from invoking the `!` chatbot handler which can trigger expensive LLM/tool operations using the operator's credentials by enforcing an allowlist of user IDs.

### Description
- Parse `ALLOWED_USER_IDS` from the environment into `ALLOWED_USER_IDS` at module load and enforce a guard in `on_message` that returns early (and logs a warning) if `str(message.author.id)` is not in the allowlist in `discord_bot/chat_handler.py`.

### Testing
- Ran `python -m compileall discord_bot/chat_handler.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ec238d088330927c0aaf76e609ce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-level authorization for the chatbot: only authorized users can interact with and invoke the bot; messages from unauthorized users are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->