### PR TITLE
Guard DB initialization, manage backfill lifecycle, and clean up error/close handling

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -1,3 +1,4 @@
+import asyncio
 import asyncpg
 import logging
 from typing import List, Optional, Dict, Set
@@ -7,6 +8,7 @@ from core.config import POSTGRES_URL
 logger = logging.getLogger(__name__)
 
 pool: Optional[asyncpg.Pool] = None
+_init_lock = asyncio.Lock()
 
 
 async def init_db():
@@ -19,13 +21,28 @@ async def init_db():
         Exception: If creating the connection pool or initializing the schema fails; the original exception is propagated.
     """
     global pool
-    try:
-        pool = await asyncpg.create_pool(POSTGRES_URL)
-        logger.info("Database connection pool created.")
-        await create_schema()
-    except Exception as e:
-        logger.error(f"Failed to initialize database: {e}")
-        raise
+    async with _init_lock:
+        if pool and not pool.is_closing():
+            logger.info("Database connection pool already initialized.")
+            return
+
+        new_pool: Optional[asyncpg.Pool] = None
+        try:
+            new_pool = await asyncpg.create_pool(POSTGRES_URL)
+            pool = new_pool
+            logger.info("Database connection pool created.")
+            await create_schema()
+        except Exception as e:
+            if new_pool is not None:
+                try:
+                    await new_pool.close()
+                except Exception:
+                    logger.exception("Failed to close database pool during init cleanup")
+                finally:
+                    if pool is new_pool:
+                        pool = None
+            logger.error(f"Failed to initialize database: {e}")
+            raise
 
 
 async def close_db():
@@ -62,10 +79,6 @@ async def create_schema():
             -- Optimized index for fetching recent messages (DESC order)
             CREATE INDEX IF NOT EXISTS idx_messages_channel_created
             ON messages (channel_id, created_at DESC);
-
-            -- Index for message_id lookups (upserts)
-            CREATE INDEX IF NOT EXISTS idx_messages_message_id
-            ON messages (message_id);
 
             -- Drop old ASC index if it exists
             DROP INDEX IF EXISTS idx_messages_channel_created_asc;

--- a/discord_bot/chat_handler.py
+++ b/discord_bot/chat_handler.py
@@ -1,5 +1,6 @@
 # chat_handler.py
 import asyncio
+import inspect
 import logging
 import os
 import sys
@@ -110,6 +111,7 @@ def setup_chat(bot):
         "ids": set(),
         "admins": set(),
     }
+    backfill_task: Optional[asyncio.Task] = None
 
     def _is_master_user(user_id: int) -> bool:
         """
@@ -144,7 +146,7 @@ def setup_chat(bot):
         """
         Check whether a user is permitted to use chat features under the current access control settings.
         
-        Master users are always permitted. In "blacklist" mode, users are permitted unless their ID is listed; in "whitelist" mode, users are permitted only if their ID is listed.
+        Master users and admins are always permitted. In "blacklist" mode, other users are permitted unless their ID is listed; in "whitelist" mode, other users are permitted only if their ID is listed.
         
         Parameters:
             user_id (int): Discord user ID to evaluate.
@@ -152,7 +154,7 @@ def setup_chat(bot):
         Returns:
             `true` if the user is authorized, `false` otherwise.
         """
-        if _is_master_user(user_id):
+        if _is_admin_user(user_id):
             return True
 
         normalized = str(user_id)
@@ -454,15 +456,32 @@ def setup_chat(bot):
             except Exception as e:
                 logger.error(f"[on_ready] Backfill/sync task failed: {e}", exc_info=True)
 
+        nonlocal backfill_task
+        if backfill_task and not backfill_task.done():
+            logger.info("[on_ready] Backfill+sync task is already running; skipping duplicate startup")
+            return
+
         logger.info(
-            f"[on_ready] Creating backfill+sync background task for {len(text_channels)} channels..."
+            "[on_ready] Creating backfill+sync background task for %s channels...",
+            len(text_channels),
         )
-        asyncio.create_task(run_backfill_and_sync())
+        backfill_task = asyncio.create_task(run_backfill_and_sync())
         logger.info("[on_ready] Backfill+sync task created - running in background")
 
     @bot.event
     async def on_disconnect():
         """Clean shutdown of database connections and resources."""
+        nonlocal backfill_task
+        if backfill_task and not backfill_task.done():
+            logger.info("[on_disconnect] Cancelling backfill+sync background task...")
+            backfill_task.cancel()
+            try:
+                await backfill_task
+            except asyncio.CancelledError:
+                logger.info("[on_disconnect] Backfill+sync background task cancelled")
+            finally:
+                backfill_task = None
+
         logger.info("[on_disconnect] Bot disconnecting, closing database pool...")
         await close_db()
 
@@ -559,7 +578,9 @@ def setup_chat(bot):
                     )
                 except Exception as e:
                     logger.exception(f"[chatbot] Failed to generate reply for user {user_id}")
-                    await message.channel.send(f"**Error:** Failed to process request: {str(e)[:500]}")
+                    await message.channel.send(
+                        "An internal error occurred while processing your request. The team has been notified."
+                    )
                     return
 
                 end_time = time.time()
@@ -607,9 +628,8 @@ async def main_cli():
             try:
                 close_call = getattr(mcp, "close", None)
                 if close_call:
-                    if hasattr(close_call, "__await__"):
-                        await close_call()
-                    else:
-                        close_call()
+                    maybe_result = close_call()
+                    if inspect.isawaitable(maybe_result):
+                        await maybe_result
             except Exception:
                 pass


### PR DESCRIPTION
### Motivation
- Prevent concurrent initialization races and ensure the DB pool is properly cleaned up if creation fails.  
- Avoid starting duplicate backfill+sync background tasks and ensure they are cancelled on bot disconnect.  
- Reduce leakage of internal errors to end users and correctly await possibly-async `close` handlers in CLI shutdown.  

### Description
- In `core/database.py` added an `asyncio.Lock` (`_init_lock`) and wrapped `init_db()` to skip reinitialization when the pool is already active, create a `new_pool` for safe assignment, and close it on initialization failure to avoid leaking connections; removed creation of the `idx_messages_message_id` index from the schema SQL.  
- In `discord_bot/chat_handler.py` added `inspect` import and a `backfill_task` handle, prevented duplicate backfill starts by checking `backfill_task` before creating a new task, and cancel/awaited the task on `on_disconnect`.  
- Updated authorization to treat admins as master users by checking `_is_admin_user` in `_is_authorized_user`, replaced detailed exception text sent to users with a generic internal error message, used `inspect.isawaitable` to correctly await `close` handlers in `main_cli`, and adjusted a logging call to use formatting args.  

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3ff4e26488330984a40c34b7da925)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin users can now perform administrative actions alongside master users.

* **Bug Fixes**
  * Strengthened database initialization with concurrent access protection.
  * Improved error handling with user-friendly messages instead of technical details.
  * Enhanced resource cleanup during initialization failures and graceful shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->